### PR TITLE
David branch

### DIFF
--- a/checkout-android/src/main/java/com/paystack/checkout/PaystackCheckout.kt
+++ b/checkout-android/src/main/java/com/paystack/checkout/PaystackCheckout.kt
@@ -47,6 +47,7 @@ class PaystackCheckout private constructor(
             metadata
         )
 
+    //fix issues
      private lateinit var resultListener: CheckoutResultListener
 
     private val preContractStartActivityResult =

--- a/checkout-android/src/main/java/com/paystack/checkout/PaystackCheckout.kt
+++ b/checkout-android/src/main/java/com/paystack/checkout/PaystackCheckout.kt
@@ -47,14 +47,21 @@ class PaystackCheckout private constructor(
             metadata
         )
 
-    fun charge(resultListener: CheckoutResultListener) {
+     private lateinit var resultListener: CheckoutResultListener
+
+    private val preContractStartActivityResult =
         activity.registerForActivityResult(PayWithCheckout(), resultRegistry) { chargeResult ->
             when (chargeResult) {
                 is ChargeResult.Success -> resultListener.onSuccess(chargeResult.transaction)
                 is ChargeResult.Error -> resultListener.onError(chargeResult.exception)
                 ChargeResult.Cancelled -> resultListener.onCancelled()
             }
-        }.launch(chargeParams)
+        }
+
+
+    fun charge(resultListener: CheckoutResultListener) {
+        this.resultListener = resultListener
+        preContractStartActivityResult .launch(chargeParams)
     }
 
     class Builder(


### PR DESCRIPTION
There was an error in registerForActivityResult when called in an action such as button click. It throws an error that lifecycle must call register before they are created. this happens when the charge function is called and it leads to a crash. I have fixed the error. Please take a look at it. 